### PR TITLE
Fix server-side limit of query results

### DIFF
--- a/bact_archiver/archiver.py
+++ b/bact_archiver/archiver.py
@@ -145,6 +145,9 @@ class ArchiverBasis(ArchiverInterface):
         # cmds :
         opts = ''
         opt = '?{}={}'
+        # Disable server-side limit of 500 entries
+        if not 'limit' in kw.keys():
+            kw['limit'] = '-1'
         for k, v in kwargs.items():
             opts += opt.format(k, v)
             opt = '&{}={}'


### PR DESCRIPTION
The current implementation is prone to human errors due to it not enabling limitless query results by default. As can be shown using the following manual queries to the appliance, the parameter `limit` has to be set to `-1` in order to fix the server-imposed limit of 500:

```console
$ curl -s "http://www.bessy.de/archiver/BESSY/retrieval/bpl/getMatchingPVs?pv=*" | tr , '\n' | wc -l
500
$ curl -s "http://www.bessy.de/archiver/BESSY/retrieval/bpl/getMatchingPVs?pv=*&limit=-1" | tr , '\n' | wc -l
79328
```

The patch fixes this by dynamically adding the keyword `limit` set to `-1` if it is not already part of the query within `bact_archiver.archiver.askAppliance`.

Is the new behaviour acceptable? Would you be willing to merge this change?